### PR TITLE
Tweak documentation to explain how to use Cavy without the CLI

### DIFF
--- a/docs/getting-started/installing.md
+++ b/docs/getting-started/installing.md
@@ -4,14 +4,16 @@ title: Installing
 sidebar_label: Installing
 ---
 
-_To help you get started Cavy provides a command-line interface (called
-cavy-cli) which makes it easier to get set up and run your tests._
+To help you get started Cavy provides a command-line interface (called
+cavy-cli) which makes it easier to get set up and run your tests.
 
-_You can also run Cavy tests without cavy-cli. In which case, skip the CLI
-installation step and just install cavy. You may want to do this if:_
+You can also run Cavy tests without cavy-cli. In which case, skip the CLI
+installation step and just install cavy. You may want to do this if:
 
-- _You're using Expo (not currently supported via the CLI)_
-- _You're integrating Cavy with your own custom reporting (e.g. [Cavy Native Reporter](../guides/cavy-native-reporter/installing-and-usage))_
+- You're using Expo (not currently supported via the CLI)
+- You're integrating Cavy with your own custom reporting (e.g. [Cavy Native Reporter](../guides/cavy-native-reporter/installing-and-usage))
+
+---
 
 To get started with Cavy, install **cavy-cli** globally using yarn or npm:
 

--- a/docs/getting-started/installing.md
+++ b/docs/getting-started/installing.md
@@ -4,12 +4,12 @@ title: Installing
 sidebar_label: Installing
 ---
 
-_In these guides, we'll use cavy-cli to get set up and run tests. You can also
-use Cavy without the CLI. Have a look at the [Cavy README](https://github.com/pixielabs/cavy)
-for help with this. Please note that you can't use the CLI with Expo apps._
+_To help you get started Cavy provides a command-line interface (called
+cavy-cli) which makes it easier to get set up and run your tests. You can't use
+the CLI if you use Expo. In which case, skip the CLI installation step and just
+install `cavy`._
 
-To get started with Cavy, install **cavy-cli** globally using yarn
-(or npm if preferred):
+To get started with Cavy, install **cavy-cli** globally using yarn or npm:
 
     yarn global add cavy-cli
 

--- a/docs/getting-started/installing.md
+++ b/docs/getting-started/installing.md
@@ -5,9 +5,13 @@ sidebar_label: Installing
 ---
 
 _To help you get started Cavy provides a command-line interface (called
-cavy-cli) which makes it easier to get set up and run your tests. You can't use
-the CLI if you use Expo. In which case, skip the CLI installation step and just
-install `cavy`._
+cavy-cli) which makes it easier to get set up and run your tests._
+
+_You can also run Cavy tests without cavy-cli. In which case, skip the CLI
+installation step and just install cavy. You may want to do this if:_
+
+- _You're using Expo (not currently supported via the CLI)_
+- _You're integrating Cavy with your own custom reporting (e.g. [Cavy Native Reporter](../guides/cavy-native-reporter/installing-and-usage))_
 
 To get started with Cavy, install **cavy-cli** globally using yarn or npm:
 

--- a/docs/getting-started/running-tests.md
+++ b/docs/getting-started/running-tests.md
@@ -12,7 +12,7 @@ components hooked up, and your test cases written.
 The final step before you can run your tests is to import them and pass them to
 the Cavy Tester.
 
-Open `index.test.js` (or `index.{ios,android}.js` for non-cli users), import
+Open `index.test.js` (or your application entry file for non-cli users), import
 your tests, and replace the `ExampleSpec` in the Tester's `specs` prop with
 your specs:
 

--- a/docs/getting-started/running-tests.md
+++ b/docs/getting-started/running-tests.md
@@ -9,14 +9,15 @@ components hooked up, and your test cases written.
 
 ## Importing your specs
 
-The final step before you can run your tests is to import them in `index.test.js`
-and pass them to the Cavy Tester.
+The final step before you can run your tests is to import them and pass them to
+the Cavy Tester.
 
-Open `index.test.js`, import your tests, and replace the `ExampleSpec` in the 
-Tester's `specs` prop with your specs:
+Open `index.test.js` (or `index.{ios,android}.js` for non-cli users), import
+your tests, and replace the `ExampleSpec` in the Tester's `specs` prop with
+your specs:
 
 ```jsx
-// index.test.js
+// index.test.js or your app entry point.
 
 import React, { Component } from 'react';
 import { AppRegistry } from 'react-native';
@@ -74,6 +75,16 @@ the entry point Cavy should use. [See the guide for custom entry points](../guid
 
 * By default, Cavy sends its test report to cavy-cli, but you can also use a
 custom reporter. [See the guide on writing your own custom reporter](../guides/writing-custom-reporters).
+
+## Running tests without cavy-cli
+
+If you've been following along without cavy-cli, your tests will just
+automatically run when you boot your app. It's down to you to decide how to 
+control this within your app so that they only run when you want them to.
+
+You could try [swapping your app to use cavy-cli](../getting-started/setting-cavy-up#if-you-are-using-cavy-cli)
+or finding some way to configure your app to not mount a Cavy `<Tester>`
+component during boot.
 
 ## Sample app
 

--- a/docs/getting-started/setting-cavy-up.md
+++ b/docs/getting-started/setting-cavy-up.md
@@ -4,6 +4,11 @@ title: Setting up the Cavy Tester
 sidebar_label: Setting up the Cavy Tester
 ---
 
+ * [I am using cavy-cli](#if-you-are-using-cavy-cli)
+ * [I am not using cavy-cli](#if-you-are-not-using-cavy-cli)
+
+## If you are using cavy-cli
+
 Once you've downloaded cavy-cli and added Cavy to your project, you're ready to
 get started. From within your React Native project, run:
 
@@ -51,6 +56,34 @@ and renders your app inside Cavy's Tester component so that the tests run on boo
 **NOTE:** Cavy assumes that your app entry point will be named `index.js`. If this is not
 the case, see [Specifying a custom app entry point](../guides/specifing-a-custom-app-entry-point).
 
+## If you are not using cavy-cli
+
+Import Tester, TestHookStore and your specs in your top-level JS file
+(typically this is your `index.{ios,android}.js` files). Instantiate a new
+TestHookStore and render your app inside a Tester.
+
+```jsx
+// index.ios.js
+
+import React, { Component } from 'react';
+import { Tester, TestHookStore } from 'cavy';
+import ExampleSpec from './specs/exampleSpec';
+import App from './app';
+
+const testHookStore = new TestHookStore();
+
+export default class AppWrapper extends Component {
+  render() {
+    return (
+      <Tester specs={[ExampleSpec]} store={testHookStore}>
+        <App />
+      </Tester>
+    );
+  }
+}
+```
+
 #### More on the Tester component
 
 * [Tester component API](../api/tester)
+

--- a/docs/guides/specifing-a-custom-app-entry-point.md
+++ b/docs/guides/specifing-a-custom-app-entry-point.md
@@ -4,6 +4,8 @@ title: Specifing a custom app entry point
 sidebar_label: Specifing a custom app entry point
 ---
 
+_This guide is only relevant if you're running Cavy with cavy-cli._
+
 By default, Cavy looks for an `index.js` entry point in your React Native project.
 Running `cavy init` will generate a corresponding `index.test.js` file,
 which is used to make sure that your tests only run


### PR DESCRIPTION
This is a bit of a first stab. I've basically identified the points where you use `index.test.js` or `cavy` commands and explained what you'd need to do if you weren't using the CLI. It's not perfect, but it's better than an entirely separate guide because most of the process is actually the same.

Thoughts / suggestions welcome. Once this goes in, I think we can massively reduce all the README contents, which will save us a lot of time.