### PR TITLE
Documentation for new `wrap` functionality

### DIFF
--- a/docs/api/test-hooks.md
+++ b/docs/api/test-hooks.md
@@ -1,5 +1,5 @@
 ---
-id: test-hooks 
+id: test-hooks
 title: Test Hooks
 ---
 
@@ -14,89 +14,117 @@ test hooks.
 
 ### `generateTestHook(identifier, [func])`
 
-Returns the ref generating function that adds components to the TestHookStore, if
-defined.
+Returns the ref generating function that adds components to the TestHookStore.
 
 * `identifier`: (`String`) Identifier for the component that is used in tests.
 * `func`: (`Function`) Optional - your own ref generating function.
 
---- 
-### `hook(wrappedComponent)`
+---
+### `useCavy()`
 
-Higher-order React component that makes `generateTestHook` available as props to
-the children of a component.
-
-* `wrappedComponent` - React Component to be wrapped.
+Cavy's custom React Hook that returns the `generateTestHook` function.
 
 #### Example
 
-```jsx
-import { hook } from cavy;
+```js
+import { useCavy } from 'cavy';
 
-class MyComponent extends React.Component {
+export default ()  => {
+  const generateTestHook = useCavy();
+  return <input ref={ generateTestHook('Input') }/>
+}
+```
+
+---
+### `hook(wrappedComponent)`
+
+Higher-order React component that makes `generateTestHook` available as a prop.
+An alternative to `useCavy()`.
+
+* `wrappedComponent` - React component to be wrapped.
+
+#### Example
+
+```js
+import React from 'react';
+import { hook } from 'cavy';
+
+class Scene extends React.Component {
   render() {
     const { generateTestHook } = this.props;
 
     return (
       <TextInput
-        ref={generateTestHook('MyComponent.textinput', (c) => this.textInput = c)}
-        ...
+        ref={generateTestHook('Scene.TextInput', (c) => this.textInput = c)}
       />
       <Button
-        ref={generateTestHook('MyComponent.button')}
+        ref={generateTestHook('Scene.Button')}
         title='Press me!'
       />
     );
   }
 }
 
-const TestableMyComponent = hook(MyComponent);
-export default TestableMyComponent;
+const TestableScene = hook(Scene);
+export default TestableScene;
 ```
 
 ---
-### `wrap(functionComponent)`
+### `wrap(component)`
 
-Higher-order React component that wraps a function component using React's
-[`forwardRef`](https://reactjs.org/docs/forwarding-refs.html) and
+Higher order React component that makes non-testable components testable.
+
+#### 1. Function components
+
+`wrap` uses [`forwardRef`](https://reactjs.org/docs/forwarding-refs.html) and
 [`useImperativeHandle`](https://reactjs.org/docs/hooks-reference.html#useimperativehandle)
-to make its properties available via the ref so that Cavy can interact with via
-the TestHookStore.
+to make a function component's props available via the ref so that Cavy can
+interact with it during testing:
 
-* `functionComponent` - The function component you want to test.
-
-#### Example
-
-```jsx
-import { Button } from 'react-native-elements';
-import { hook, wrap } from 'cavy';
-
-class MyComponent extends React.Component {
-  // ...
-  render() {
-    const WrappedButton = wrap(Button);
-
-    return (
-      <WrappedButton ref={this.generateTestHook('button')} onPress={}/>
-    )
-  }
-}
-export default hook(MyComponent);
-```
-
----
-### `useCavy()`
-
-Custom React Hook that returns a function that you can pass into an inner
-component's ref to add that component to the TestHookStore.
+* `component` - The function component you want to test.
 
 #### Example
 
-```jsx
-import { useCavy } from 'cavy';
+```js
+import { FunctionComponent } from 'some-ui-library';
+import { useCavy, wrap } from 'cavy';
 
-export default ()  => {
+export default () => {
   const generateTestHook = useCavy();
-  return <input ref={ generateTestHook('MyInput') }/>
-}
+  const TestableFunctionComponent = wrap(FunctionComponent);
+
+  return (
+    <TestableFunctionComponent
+      ref={generateTestHook('Scene.FunctionComponent')}
+    />   
+  )
+};
 ```
+
+
+#### 2. Native components like `<Text>`
+`wrap` wraps a native component like `Text`, (which is neither a React Class nor
+a Function Component), and returns a React Class with testable props.
+
+* `component` - The function component you want to test.
+
+#### Example
+
+```js
+import { Text } from 'react-native';
+import { useCavy, wrap } from 'cavy';
+
+export default () => {
+  const generateTestHook = useCavy();
+  const TestableText = wrap(Text);
+
+  return (
+    <TestableText
+      ref={generateTestHook('Scene.Text')}
+    />   
+  )
+};
+```
+
+**Note:** If you only want to test the presence of a `<Text>` component, you do
+not need to wrap it before assigning it a ref.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,6 +4,12 @@ title: Frequently Asked Questions
 sidebar_label: Cavy FAQ's
 ---
 
+### I'm trying to test a `<Text>` component and am getting the error: `Cannot read property 'children' of undefined`
+
+You need to `wrap` your `<Text>` component before testing it, otherwise Cavy
+does not have access to its props. [See the API documentation](./api/test-hooks#wrapcomponent)
+for examples of using the `wrap` function.
+
 ### How does Cavy compare to Appium? What is the benefit?
 
 Cavy is a comparable tool to Appium. The key difference is that Appium uses

--- a/docs/getting-started/hooking-up-components.md
+++ b/docs/getting-started/hooking-up-components.md
@@ -1,6 +1,6 @@
 ---
 id: hooking-up-components
-title: Hooking up components 
+title: Hooking up components
 sidebar_label: Hooking up components
 ---
 
@@ -15,7 +15,7 @@ register the components you want to interact with in your tests.
 
 Cavy uses [React ref generating functions](https://reactjs.org/docs/refs-and-the-dom.html).
 We'll pass our components a ref using `generateTestHook`, which returns the
-ref generating function that adds components to the TestHookStore, making them
+ref generating function that adds components to the `TestHookStore`, making them
 available to us in our specs.
 
 `generateTestHook` takes a string as an argument, which is the identifier
@@ -23,25 +23,23 @@ we'll use in our tests to reference the component. It can be anything you
 like - make sure to use something that is easy to understand to keep your tests
 readable!
 
-There are three ways of getting access to `generateTestHook`:
+There are two ways of getting access to `generateTestHook`:
 
-* [`useCavy()` React Hook](#usecavy-react-hook) - the modern approach
-* [Cavy's `hook` function](#using-cavy-s-hook-function) - the older approach
-* [Cavy's `wrap` function](#using-cavy-s-wrap-function) - when you want to
-  interact with a function component you don't control.
+* using [`useCavy()` React Hook](#usecavy-react-hook) - the modern approach
+* using [`hook()` function](#hook-function) - the older approach
+
+For testing function components that cannot be assigned a ref directly, you can
+use Cavy's [`wrap` function](#wrap-function) to create testable versions of
+these components. You will also need to `wrap` native components like `Text`.
 
 ### `useCavy()` React Hook
 
-If you're using React Hooks and would like to test a function component, you can
-call the custom `useCavy()` React Hook to obtain the `generateTestHook` function
-that you can pass to inner components' refs:
+If you're using React Hooks, you can call the custom `useCavy()` React Hook to
+obtain the `generateTestHook` function and assign a ref to the component you
+want to test:
 
-```jsx
-// src/components/MyComponent.js
-
-import React, { Component } from 'react';
+```js
 import { View, TextInput } from 'react-native';
-
 import { useCavy } from 'cavy';
 
 export default () => {
@@ -50,7 +48,7 @@ export default () => {
   return (
     <View>
       <TextInput
-        ref={generateTestHook('MyComponent.TextInput')}
+        ref={generateTestHook('Scene.TextInput')}
         onChangeText={...}
       />
     </View>   
@@ -58,22 +56,19 @@ export default () => {
 };
 ```
 
-### Using Cavy's `hook` function
+### `hook()` function
 
-Cavy provides a `hook` function which makes `generateTestHook` available as props.
-You'll need to import the `hook` function, add a ref using the `generateTestHook`
-function, then export a hooked version of the parent component:
+Cavy also provides a `hook` function which makes `generateTestHook` available as
+in props. As assign a red to the component you want to test and then export a
+hooked version of your parent component:
 
-```jsx
-// src/Scene.js
-
-import React, { Component } from 'react';
+```js
+import React from 'react';
 import { View, TextInput } from 'react-native';
 import { hook } from 'cavy';
 
-class Scene extends Component {
+class Scene extends React.Component {
   render() {
-
     return (
       <View>
         <TextInput
@@ -89,47 +84,64 @@ const TestableScene = hook(Scene);
 export default TestableScene;
 ```
 
-### Using Cavy's `wrap` function
+### `wrap()` function
 
-If you'd like to test a function component to which you can't assign a ref,
-for example if you're importing a third-party function component, create
-a testable version of it using the `wrap` function, then assign it a ref using
-`generateTestHook` as normal.
+You can use Cavy's `wrap` function to achieve two things:
 
-```jsx
-// src/Scene.js
+#### 1. Testing function components
 
-import React, { Component } from 'react';
-import { View } from 'react-native';
+If you'd like to test a function component to which you can't assign a ref (for
+example if you're importing a third-party function component), create a testable
+version of it using the `wrap` function, then assign it a ref as normal using
+`generateTestHook`:
+
+```js
 import { FunctionComponent } from 'some-ui-library';
-import { hook, wrap } from 'cavy';
+import { useCavy, wrap } from 'cavy';
 
-class Scene extends Component {
-  render() {
-    // Wrap a function component to which you can't assign a ref so that
-    // you can test it with Cavy.
-    const TestableFunctionComponent = wrap(FunctionComponent);
+export default () => {
+  const generateTestHook = useCavy();
+  const TestableFunctionComponent = wrap(FunctionComponent);
 
-    return (
-      <View>
-        <TestableFunctionComponent
-          ref={this.props.generateTestHook('Scene.FunctionComponent')}
-          otherProp={...}
-        />
-      </View>      
-    );
-  }
-}
-
-// You need to wrap the Scene component in Cavy's `hook` function to make
-// `generateTestHook` available to it.
-const TestableScene = hook(Scene);
-export default TestableScene;
+  return (
+    <TestableFunctionComponent
+      ref={generateTestHook('Scene.FunctionComponent')}
+    />   
+  )
+};
 ```
+
+#### 2. Testing native components like `<Text>`
+
+If you want to test a `<Text>` component using the `containsText` helper method,
+or by accessing it's props directly, **you must wrap the Text component
+itself**:
+
+```js
+import { Text } from 'react-native';
+import { useCavy, wrap } from 'cavy';
+
+export default () => {
+  const generateTestHook = useCavy();
+  const TestableText = wrap(Text);
+
+  return (
+    <TestableText
+      ref={generateTestHook('Scene.Text')}
+    />   
+  )
+};
+```
+
+If you assign a ref directly to `<Text>`, the component returned does not expose
+the props and you will not be able to test the children it renders.
+
+**Note:** If you only want to test the presence of a `<Text>` component, you do
+not need to wrap it before assigning it a ref.
 
 #### See also
 
 * [`generateTestHook`](../api/test-hooks#generatetesthookidentifier-func)
 * [`hook`](../api/test-hooks#hookwrappedcomponent)
-* [`wrap`](../api/test-hooks#wrapfunctioncomponent)
+* [`wrap`](../api/test-hooks#wrapcomponent)
 * [`useCavy`](../api/test-hooks#usecavy)

--- a/docs/guides/writing-spec-helpers.md
+++ b/docs/guides/writing-spec-helpers.md
@@ -11,36 +11,32 @@ Your function will need to be **asynchronous** and should **throw an error** in
 situations where you want the test to fail.
 
 
-For example, the following tests whether a `<Text>` component displays the
-correct text:
+For example, the following tests whether a `<Button>` component is disabled:
 
 ```js
 // specs/helpers.js
 
-export async function containsText(component, text) {
-  if (!component.props.children.includes(text)) {
-    throw new Error(`Could not find text ${text}`);
+export async function isDisabled(button) {
+  if (!button.props.disabled) {
+    throw new Error(`Button not disabled.`);
   };
 }
 ```
 
-Then in your spec, you can import your helper and use it as you would any
-other helper:
-
+Then in your spec, you can import your helper and pass in the component using
+`findComponent()`:
 
 ```js
 // specs/AppSpec.js
 
-// Import your spec helper
-import { containsText } from './helpers';
+import { isDisabled } from './helpers';
 
 export default function(spec) {
-  spec.describe('Changing the text', function() {
-    spec.it('works', async function() {
-      await spec.press('Scene.button');
-      const text = await spec.findComponent('Scene.text');
-      // Use your spec helper to test that the correct text is displayed
-      await containsText(text, 'you pressed the button');
+  spec.describe('The button', function() {
+    spec.it('is disabled', async function() {
+      const button = await spec.findComponent('Scene.Button');
+      // Use your spec helper to test that the button is disabled
+      await isDisabled(button);
     });
   });
 }


### PR DESCRIPTION
- Adds new documentation for `wrap()` and it's use with native components like `<Text>`.
- Includes the peculiarities around testing `<Text>` components to the FAQs.
- Shuffles around things so that `useCavy()` is mentioned before `hook()` as this is the new API.
- Uses function components in examples unless we're specifically talking about classes.
- Fixes the old example of creating your own spec helper (used to be for a Text component).