### PR TITLE
fix: installing types with yarn should use --dev flag

### DIFF
--- a/docs/getting-started/installing.md
+++ b/docs/getting-started/installing.md
@@ -27,4 +27,4 @@ Add Cavy to your React Native project as a development dependency:
 
 If you're using TypeScript, you'll also need to install the types package:
 
-    yarn add @types/cavy
+    yarn add @types/cavy --dev


### PR DESCRIPTION
Similar to installing the `cavy` dependency, the types for it should be installed into the `devDependencies` 😊 