### PR TITLE
Add more examples to documentation

### DIFF
--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -40,9 +40,6 @@ looks for an `index.js`.
 building the app. Assumes your app is already running.
 * `-d, --dev`: Start the test server and keep it running until manually killed.
 For use with hot-reloading.
-* `--xml`: Write the test results to an XML file which conforms to JUnit
-specification so that you can integrate Cavy with CI tools.
-
 
 `rn-options:`
 * Any [react-native-cli](https://www.npmjs.com/package/react-native-cli) options that are valid for `react-native run-ios`.

--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -40,6 +40,9 @@ looks for an `index.js`.
 building the app. Assumes your app is already running.
 * `-d, --dev`: Start the test server and keep it running until manually killed.
 For use with hot-reloading.
+* `--xml`: Write the test results to an XML file which conforms to JUnit
+specification so that you can integrate Cavy with CI tools.
+
 
 `rn-options:`
 * Any [react-native-cli](https://www.npmjs.com/package/react-native-cli) options that are valid for `react-native run-ios`.

--- a/docs/api/helpers.md
+++ b/docs/api/helpers.md
@@ -14,6 +14,16 @@ Creates a block that groups together several related test cases.
 * `label`: (`String`) Label for the test cases.
 * `function`: (`Function`) Callback function containing your test cases.
 
+#### Example
+
+```js
+export default function(spec) {
+  spec.describe('My Scene', function() {
+    // Test case goes in here
+  });
+}
+```
+
 ### `.it(label, function)`
 
 Defines a test case.
@@ -21,6 +31,18 @@ Defines a test case.
 * `label`: (`String`) Label for the test case. This is combined with the label
 from `describe` when Cavy outputs to the console.
 * `function`: (`Function`) The test case.
+
+#### Example
+
+```js
+export default function(spec) {
+  spec.describe('My Scene', function() {
+    spec.it('Has a component', async function() {
+      await spec.exists('MyScene.MyComponent');
+    });
+  });
+}
+```
 
 ### `.beforeEach(function)`
 Runs a function before each test case. This function is called after Cavy
@@ -55,16 +77,55 @@ to `onChangeText`.
 * `identifier`: (`String`) Identifier for the component.
 * `str`: (`String`) String to fill in.
 
+#### Example
+
+```js
+export default function(spec) {
+  spec.describe('A list of employees', function() {
+    spec.it('can be filtered by search input', async function() {
+      await spec.fillIn('SearchBar.TextInput', 'Amy');
+      await spec.exists('EmployeeList.AmyTaylor');
+    });
+  });
+}
+```
+
 ### `.focus(identifier)`
 Focuses the identified component. Component must respond
 to `onFocus`.
 
 * `identifier`: (`String`) Identifier for the component.
 
+#### Example
+
+```js
+export default function(spec) {
+  spec.describe('Focusing on the new password field', function() {
+    spec.it('reveals the password constraints', async function() {
+      await spec.focus('Password.New');
+      await spec.exists('Password.Constraints');
+    });
+  });
+}
+```
+
 ### `.press(identifier)`
 Presses the identified component. Component must respond to `onPress`.
 
 * `identifier`: (`String`) Identifier for the component.
+
+#### Example
+
+```js
+export default function(spec) {
+  spec.describe('Pressing the "Gallery" button', function() {
+    spec.it('takes the user to the employee image gallery', async function() {
+      await spec.press('Button.ToGallery');
+      await spec.exists('Employees.ImageGallery');
+    });
+  });
+}
+```
 
 ### `.pause(time)`
 
@@ -72,6 +133,20 @@ Pauses the test for the given length of time in milliseconds. Useful if you need
 to allow time for a response to be received before progressing.
 
 * `time`: (`Number`) The amount of time to wait in milliseconds.
+
+#### Example
+
+```js
+export default function(spec) {
+  spec.describe('Selecting an employee', function() {
+    spec.it('reveals the email button after of 1 second', async function() {
+      await spec.press('EmployeeImage.AmyTaylor');
+      await spec.pause(1000);
+      await spec.exists('ActionBar.EmailButton');
+    });
+  });
+}
+```
 
 ### `.findComponent(identifier)`
 
@@ -86,8 +161,17 @@ via `generateTestHook`.
 #### Example
 
 ```js
-const picker = await spec.findComponent('Scene.modalPicker');
-picker.open();
+export default function(spec) {
+  import { hasButtonText } from './helpers';
+
+  spec.describe('Navigating to an employee profile', function() {
+    spec.it('reveals the email button with correct text', async function() {
+      await spec.press('EmployeeImage.AmyTaylor');
+      const button = await spec.findComponent('ActionBar.EmailButton');
+      await hasButtonText(button, 'Email Amy');
+    });
+  });
+}
 ```
 
 ## Assertions
@@ -103,3 +187,16 @@ Returns `true` if the component is absent from the screen.
 
 * `identifier`: (`String`) Identifier for the component.
 
+#### Example
+```js
+export default function(spec) {
+  spec.describe('A list of the employees', function() {
+    spec.it('can be filtered by search input', async function() {
+      await spec.exists('EmployeeList.JimCavy');
+      await spec.fillIn('SearchBar.TextInput', 'Amy');
+      await spec.notExists('EmployeeList.JimCavy');
+      await spec.exists('EmployeeList.AmyTaylor');
+    });
+  });
+}
+```

--- a/docs/api/helpers.md
+++ b/docs/api/helpers.md
@@ -19,7 +19,7 @@ Creates a block that groups together several related test cases.
 ```js
 export default function(spec) {
   spec.describe('My Scene', function() {
-    // Test case goes in here
+    // A group of test cases goes here
   });
 }
 ```

--- a/docs/api/tester.md
+++ b/docs/api/tester.md
@@ -37,7 +37,10 @@ const testHookStore = new TestHookStore();
 export default class AppWrapper extends React.Component {
   render() {
     return (
-      <Tester specs={[MyFeatureSpec, OtherFeatureSpec]} store={testHookStore}>
+      <Tester
+        specs={[MyFeatureSpec, OtherFeatureSpec]}
+        store={testHookStore}
+      >
         <App />
       </Tester>
     );


### PR DESCRIPTION
Includes:
- format example on the tester page
- add examples to the documentation for helpers