### PR TITLE
Tidy up docs

### DIFF
--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -3,7 +3,7 @@ id: commands
 title: CLI Commands
 ---
 
-These commands making testing your app easier and are available with cavy-cli.
+These commands make testing your app easier and are available with cavy-cli.
 
 * [See installation instructions](../getting-started/installing)
 * [View on GitHub](https://github.com/pixielabs/cavy-cli)

--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -3,7 +3,7 @@ id: commands
 title: CLI Commands
 ---
 
-Available with cavy-cli.
+These commands making testing your app easier and are available with cavy-cli.
 
 * [See installation instructions](../getting-started/installing)
 * [View on GitHub](https://github.com/pixielabs/cavy-cli)
@@ -43,7 +43,6 @@ For use with hot-reloading.
 * `--xml`: Write the test results to `cavy_results.xml`, conforming to JUnit XML
 specification. (This option requires Cavy >=3.3.0)
 
-
 `rn-options:`
 * Any [react-native-cli](https://www.npmjs.com/package/react-native-cli) options that are valid for `react-native run-ios`.
 
@@ -61,15 +60,17 @@ Simulator](https://facebook.github.io/react-native/docs/running-on-simulator-ios
 cavy run-ios -f index.ios.js --simulator="iPhone 4s"
 ```
 
-Run Cavy tests in dev mode having built and started your app independently:
+Run Cavy tests in dev mode having built and started your app manually:
 
 ```bash
 cavy run-ios -d -s
 ```
 
-#### Note
-If you choose not to skip the build, then Cavy CLI will build and run your app
-using `react-native run-ios` under the hood.
+#### Expo and cavy-cli
+By default, cavy-cli attempts to build and run your app using
+`react-native run-ios` under the hood. If you're using Expo this won't work!
+You'll have to manually build your app yourself and run your tests using the
+`--skipbuild` option.
 
 ---
 

--- a/docs/api/test-helpers.md
+++ b/docs/api/test-helpers.md
@@ -24,6 +24,8 @@ export default function(spec) {
 }
 ```
 
+---
+
 ### `.it(label, function)`
 
 Defines a test case.
@@ -43,6 +45,8 @@ export default function(spec) {
   });
 }
 ```
+
+---
 
 ### `.beforeEach(function)`
 Runs a function before each test case. This function is called after Cavy
@@ -88,6 +92,8 @@ export default function(spec) {
 }
 ```
 
+---
+
 ### `.findComponent(identifier)`
 
 Finds a component using its test hook identifier. Waits `this.waitTime` for the
@@ -119,6 +125,8 @@ export default function(spec) {
 }
 ```
 
+---
+
 ### `.focus(identifier)`
 Focuses the identified component. Component must respond
 to `onFocus`.
@@ -137,6 +145,8 @@ export default function(spec) {
   });
 }
 ```
+
+---
 
 ### `.pause(time)`
 
@@ -158,6 +168,8 @@ export default function(spec) {
   });
 }
 ```
+
+---
 
 ### `.press(identifier)`
 Presses the identified component. Component must respond to `onPress`.
@@ -196,6 +208,8 @@ export default function(spec) {
 }
 ```
 
+---
+
 ### `.containsText(identifier, str)`
 Returns `true` if the component contains the string as a child.
 
@@ -219,6 +233,8 @@ export default function(spec) {
   });
 }
 ```
+
+---
 
 ### `.notExists(identifier)`
 

--- a/docs/api/test-helpers.md
+++ b/docs/api/test-helpers.md
@@ -1,6 +1,6 @@
 ---
-id: helpers
-title: Helpers
+id: test-helpers
+title: Test Helpers
 ---
 
 Cavy provides a set of helpers for writing your test cases and interacting with

--- a/docs/api/test-hooks.md
+++ b/docs/api/test-hooks.md
@@ -3,12 +3,14 @@ id: test-hooks
 title: Test Hooks
 ---
 
-Cavy interacts with elements through their refs, adding them to the TestHookStore
-where they are stored as an array of references for later use in specs. Depending
-on the component you are trying to test, there are several ways to add these
-test hooks.
+Cavy interacts with elements through their refs, storing them as 'test hooks' in
+the `TestHookStore` so that they can be refered to in your specs. Depending on
+the type of component you are testing, there are several ways to add these test
+hooks.
 
-* [See the guides for hooking up components](../getting-started/hooking-up-components)
+If you haven't already, take a look at
+[Hooking Up Components](../getting-started/hooking-up-components) for an
+for detailed guidance on adding test hooks to your components.
 
 ## Reference
 
@@ -16,14 +18,14 @@ test hooks.
 
 Returns the ref generating function that adds components to the TestHookStore.
 
-* `identifier`: (`String`) Identifier for the component that is used in tests.
+* `identifier`: (`String`) Identifier for the component you want to test.
 * `ref`: (`Function | RefObject`) Optional - your own ref generating function or
-ref attribute created via `React.createRef()`.
+  ref attribute created via `React.createRef()`.
 
 ---
 ### `useCavy()`
 
-Cavy's custom React Hook that returns the `generateTestHook` function.
+A custom React Hook that returns the `generateTestHook` function directly.
 
 #### Example
 
@@ -37,12 +39,13 @@ export default ()  => {
 ```
 
 ---
-### `hook(wrappedComponent)`
+### `hook(component)`
 
 Higher-order React component that makes `generateTestHook` available as a prop.
 An alternative to `useCavy()`.
 
-* `wrappedComponent` - React component to be wrapped.
+* `component` - The React component within which you want access to
+`generateTestHook`.
 
 #### Example
 
@@ -75,7 +78,7 @@ export default TestableScene;
 
 Higher order React component that makes non-testable components testable.
 
-* `component` - The function component you want to test.
+* `component` - The function, or Native, component you want to test.
 
 #### 1. Function components
 

--- a/docs/api/test-hooks.md
+++ b/docs/api/test-hooks.md
@@ -9,7 +9,7 @@ the type of component you are testing, there are several ways to add these test
 hooks.
 
 If you haven't already, take a look at
-[Hooking Up Components](../getting-started/hooking-up-components) for an
+[Hooking Up Components](../getting-started/hooking-up-components)
 for detailed guidance on adding test hooks to your components.
 
 ## Reference

--- a/docs/api/tester.md
+++ b/docs/api/tester.md
@@ -4,10 +4,9 @@ title: Tester Component
 sidebar_label: Tester Component
 ---
 
-As per the instructions in
-[Setting up the Cavy Tester](getting-starts/setting-cavy-up), your app should be
-wrapped inside a `<Tester>` component within `index.test.js`. This creates a
-testable version of your app!
+As detailed in [Setting up the Cavy Tester](getting-starts/setting-cavy-up),
+your app should be wrapped inside a `<Tester>` component within `index.test.js`.
+This creates a testable version of your app!
 
 As well as the required `specs` and `store`, there are a number of optional
 props you can pass into the `<Tester>` to change the way Cavy runs test. These

--- a/docs/api/tester.md
+++ b/docs/api/tester.md
@@ -5,8 +5,8 @@ sidebar_label: Tester Component
 ---
 
 As detailed in [Setting up the Cavy Tester](getting-starts/setting-cavy-up),
-your app should be wrapped inside a `<Tester>` component within `index.test.js`.
-This creates a testable version of your app!
+your app should be wrapped inside a `<Tester>` component within `index.test.js`
+(or your app entry point). This creates a testable version of your app!
 
 As well as the required `specs` and `store`, there are a number of optional
 props you can pass into the `<Tester>` to change the way Cavy runs test. These

--- a/docs/api/tester.md
+++ b/docs/api/tester.md
@@ -4,12 +4,14 @@ title: Tester Component
 sidebar_label: Tester Component
 ---
 
-Wraps your entire app to run tests against that app, interacting
-with registered components in your test cases via the Cavy [helpers](helpers).
+As per the instructions in
+[Setting up the Cavy Tester](getting-starts/setting-cavy-up), your app should be
+wrapped inside a `<Tester>` component within `index.test.js`. This creates a
+testable version of your app!
 
-```jsx
-import { Tester } from 'cavy';
-```
+As well as the required `specs` and `store`, there are a number of optional
+props you can pass into the `<Tester>` to change the way Cavy runs test. These
+are detailed below:
 
 ## Props
 

--- a/docs/api/tester.md
+++ b/docs/api/tester.md
@@ -9,7 +9,7 @@ your app should be wrapped inside a `<Tester>` component within `index.test.js`
 (or your app entry point). This creates a testable version of your app!
 
 As well as the required `specs` and `store`, there are a number of optional
-props you can pass into the `<Tester>` to change the way Cavy runs test. These
+props you can pass into the `<Tester>` to change the way Cavy runs tests. These
 are detailed below:
 
 ## Props

--- a/docs/getting-started/hooking-up-components.md
+++ b/docs/getting-started/hooking-up-components.md
@@ -5,11 +5,10 @@ sidebar_label: Hooking up components
 ---
 
 There are two parts to writing Cavy tests: registering the components you'd like
-to test so that the Cavy Tester knows about them, and writing the
-test cases.
+to test so that Cavy knows about them, and writing the test cases.
 
 In this section, we'll cover using Cavy's `generateTestHook` function to
-register the components you want to interact with in your tests.
+hook up the components you want to interact with in your tests.
 
 ## How does this work?
 

--- a/docs/getting-started/installing.md
+++ b/docs/getting-started/installing.md
@@ -10,7 +10,7 @@ interface (called cavy-cli). We recommend you get started with this.
 You can also run Cavy tests without cavy-cli. In which case, skip the CLI
 installation step and just install cavy. You may want to do this if you're
 integrating Cavy with your own custom reporting(e.g.
-[Cavy Native Reporter](../guides/cavy-native-reporter/installing-and-usage))
+[Cavy Native Reporter](../guides/cavy-native-reporter/installing-and-usage)).
 
 Install **cavy-cli** globally using yarn or npm:
 

--- a/docs/getting-started/installing.md
+++ b/docs/getting-started/installing.md
@@ -4,22 +4,19 @@ title: Installing
 sidebar_label: Installing
 ---
 
-To help you get started Cavy provides a command-line interface (called
-cavy-cli) which makes it easier to get set up and run your tests.
+To make it easier to get set up and testing, Cavy provides a command-line
+interface (called cavy-cli). We recommend you get started with this.
 
 You can also run Cavy tests without cavy-cli. In which case, skip the CLI
-installation step and just install cavy. You may want to do this if:
+installation step and just install cavy. You may want to do this if you're
+integrating Cavy with your own custom reporting(e.g.
+[Cavy Native Reporter](../guides/cavy-native-reporter/installing-and-usage))
 
-- You're using Expo (not currently supported via the CLI)
-- You're integrating Cavy with your own custom reporting (e.g. [Cavy Native Reporter](../guides/cavy-native-reporter/installing-and-usage))
-
----
-
-To get started with Cavy, install **cavy-cli** globally using yarn or npm:
+Install **cavy-cli** globally using yarn or npm:
 
     yarn global add cavy-cli
 
-Add Cavy to your React Native project as a development dependency:
+Add **Cavy** to your React Native project as a development dependency:
 
     yarn add cavy --dev
 

--- a/docs/getting-started/installing.md
+++ b/docs/getting-started/installing.md
@@ -9,7 +9,7 @@ interface (called cavy-cli). We recommend you get started with this.
 
 You can also run Cavy tests without cavy-cli. In which case, skip the CLI
 installation step and just install cavy. You may want to do this if you're
-integrating Cavy with your own custom reporting(e.g.
+integrating Cavy with your own custom reporting (e.g.
 [Cavy Native Reporter](../guides/cavy-native-reporter/installing-and-usage)).
 
 Install **cavy-cli** globally using yarn or npm:

--- a/docs/getting-started/running-tests.md
+++ b/docs/getting-started/running-tests.md
@@ -4,13 +4,13 @@ title: Running tests
 sidebar_label: Running tests
 ---
 
-By now you should have Cavy installed, the Tester set up, your testable
-components hooked up, and your test cases written.
+By now you should have Cavy installed, the `<Tester>` set up, your testable
+components hooked up, _and_ your test cases written!
 
 ## Importing your specs
 
-The final step before you can run your tests is to import them and pass them to
-the Cavy Tester.
+The final step before you can run your tests is to import them and pass them
+into the `<Tester>`.
 
 Open `index.test.js` (or your application entry file for non-cli users), import
 your tests, and replace the `ExampleSpec` in the Tester's `specs` prop with
@@ -68,15 +68,31 @@ For a full list of cavy-cli options, see the [API reference](../api/commands).
 #### Note on running tests via cavy-cli
 
 * Under the hood, cavy-cli calls react-native-cli commands. This means you can
-pass in any react-native-cli options that are valid for either
-`react-native run-ios` or `react-native run-android`. [See the full reference
-for more on Cavy commands](../api/commands).
+  pass in any react-native-cli options that are valid for either
+  `react-native run-ios` or `react-native run-android`. [See the full reference
+  for more on Cavy commands](../api/commands).
 
 * If you're not using `index.js` as your app entry point, you'll need to specify
-the entry point Cavy should use. [See the guide for custom entry points](../guides/specifing-a-custom-app-entry-point).
+  the entry point Cavy should use.
+  [See the guide for custom entry points](../guides/specifing-a-custom-app-entry-point).
 
-* By default, Cavy sends its test report to cavy-cli, but you can also use a
-custom reporter. [See the guide on writing your own custom reporter](../guides/writing-custom-reporters).
+## Running tests with cavy-cli and Expo
+
+If you're using Expo, `cavy run-ios` or `cavy run-android` will fail to
+successfully build your app.
+
+Build your app separately and run your tests using:
+
+```bash
+# To test on iOS
+cavy run-ios --skipbuild
+
+# To test on Android
+cavy run-android --skipbuild
+```
+
+Passing in the `--skipbuild` option means that cavy-cli will assume your
+app is already running, and will wait for your test results.
 
 ## Running tests without cavy-cli
 
@@ -88,13 +104,6 @@ You could try [swapping your app to use cavy-cli](../getting-started/setting-cav
 or finding some way to configure your app to not mount a Cavy `<Tester>`
 component during boot.
 
-## Sample app
-
-Check out [the sample app](https://github.com/pixielabs/cavy/tree/master/sample-app/CavyDirectory)
-for example usage. Here it is running:
-
-![Sample app running](https://user-images.githubusercontent.com/126989/46629651-8b925e80-cb39-11e8-90b4-23d447d818f9.gif)
-
-## Find out more about the CLI
+#### Find out more about the CLI
 
  * [CLI commands reference](../api/commands#cavy-run-ios)

--- a/docs/getting-started/sample-app.md
+++ b/docs/getting-started/sample-app.md
@@ -1,0 +1,10 @@
+---
+id: sample-app
+title: Sample app
+sidebar_label: Sample app
+---
+
+For an example of a Cavy-tested React Native app, check out the code for
+[our sample app on GitHub](https://github.com/pixielabs/cavy/tree/master/sample-app/CavyDirectory).
+
+![Sample app running](https://user-images.githubusercontent.com/126989/46629651-8b925e80-cb39-11e8-90b4-23d447d818f9.gif)

--- a/docs/getting-started/setting-cavy-up.md
+++ b/docs/getting-started/setting-cavy-up.md
@@ -9,7 +9,7 @@ sidebar_label: Setting up the Cavy Tester
 
 ## If you are using cavy-cli
 
-Once you've downloaded cavy-cli and added Cavy to your project, you're ready to
+Once you've installed cavy-cli and added Cavy to your project, you're ready to
 get started. From within your React Native project, run:
 
     cavy init
@@ -58,9 +58,9 @@ the case, see [Specifying a custom app entry point](../guides/specifing-a-custom
 
 ## If you are not using cavy-cli
 
-Import Tester, TestHookStore and your specs in your top-level JS file
+Import the `Tester`, `TestHookStore` and your specs in your top-level JS file
 (typically this is your `index.{ios,android}.js` files). Instantiate a new
-TestHookStore and render your app inside a Tester.
+`TestHookStore` and render your app inside a `<Tester>` component.
 
 ```jsx
 // index.ios.js
@@ -83,7 +83,7 @@ export default class AppWrapper extends Component {
 }
 ```
 
-#### More on the Tester component
+#### Options for configuring your Tester component
 
 * [Tester component API](../api/tester)
 

--- a/docs/getting-started/writing-tests.md
+++ b/docs/getting-started/writing-tests.md
@@ -4,7 +4,7 @@ title: Writing test cases
 sidebar_label: Writing test cases
 ---
 
-Once you have your components hooked up, you're ready to write some tests.
+Once you have your components hooked up, you're ready to write some tests!
 
 ## Basic test structure
 
@@ -26,19 +26,32 @@ export default function(spec) {
 }
 ```
 
-You reference your hooked-up components using the string you provided to
-`generateTestHook` in the ref assigned to them.
+Reference your hooked-up components using the string you provided to
+`generateTestHook`.
 
-## Setup
+## Test helpers
+
+Cavy provides a set of functions you can use when writing your tests to interact
+with your components and manipulate your app.
+
+See the [Test Helper API reference](../api/test-helpers) for a comprehensive
+list of functions available.
+
+Can't find something you need? Write your own test helper function! See
+[Guides - Writing your own spec helpers](/guides/writing-spec-helpers) for
+an example of writing your own assertions.
+
+## Test execution
 
 You can use `beforeEach` to call a function before each test runs. The
 `beforeEach` function will be called after `AsyncStorage` is cleared but before
-the app re-renders and the test is run. So the order of actions for each test
-execution is:
+the app re-renders and the test is run.
+
+The order of actions for each test execution is:
 
 1. AsyncStorage is cleared (if the `clearAsyncStorage` prop is set to true in
    `Tester`)
-2. The `beforeEach` function is called (if defined for this test)
+2. The `beforeEach` function is called
 3. The app is re-rendered
 4. The test is run
 
@@ -62,85 +75,6 @@ export default function(spec) {
 ```
 
 #### See also
-
+* [Test Helpers API](../api/test-helpers)
 * [beforeEach reference](../api/test-helpers#beforeeachfunction)
 * [Tester component API](../api/tester)
-
-## The DSL
-
-Cavy gives you a set of functions which you can use when writing your tests
-to do the following:
-
-* [Querying](#querying)
-* [Interacting through touch](#interacting-through-touch)
-* [Inputting text](#inputting-text)
-* [Finding elements](#finding-elements)
-* [Pausing](#pausing)
-
-Below is an overview of what you can do with Cavy. See the [API](../api/test-helpers)
-for a more comprehensive reference.
-
-
-### Querying
-
-Cavy gives you functions to query the existence, or absence, of elements in your app:
-
-```js
-await spec.exists('MenuItem');
-await spec.notExists('OtherMenuItem');
-```
-
-### Interacting through touch
-
-You can interact with elements that respond to `onPress`, such as Buttons or other
-"Touchable" components:
-
-```js
-await spec.press('Button');
-```
-
-### Inputting text
-
-You can enter text into TextInput components:
-
-```js
-await spec.fillIn('Input');
-```
-
-### Asserting text content
-
-You can assert that a component (e.g. `<Text>`) contains a specified text string as a child.
-
-```js
-await spec.containsText('TextComponentID', 'string to be asserted');
-```
-
-### Focusing a component
-
-You can focus a component that responds to the `onFocus` prop, such as `<TextInput />`.
-
-```js
-await spec.focus('TextInputID');
-```
-
-### Finding elements
-
-You can find specific elements in order to interact with them:
-
-```js
-const link = await spec.findComponent('Scene.MyLink');
-```
-
-
-### Pausing
-
-Cavy lets you pause between interactions, which can be useful if you need to wait
-for a response before continuing:
-
-```js
- await spec.pause(3000);
-```
-
-#### Reference
-
-* [Test Helpers API](../api/test-helpers)

--- a/docs/getting-started/writing-tests.md
+++ b/docs/getting-started/writing-tests.md
@@ -63,7 +63,7 @@ export default function(spec) {
 
 #### See also
 
-* [beforeEach reference](../api/helpers#beforeeachfunction)
+* [beforeEach reference](../api/test-helpers#beforeeachfunction)
 * [Tester component API](../api/tester)
 
 ## The DSL
@@ -77,7 +77,7 @@ to do the following:
 * [Finding elements](#finding-elements)
 * [Pausing](#pausing)
 
-Below is an overview of what you can do with Cavy. See the [API](../api/helpers)
+Below is an overview of what you can do with Cavy. See the [API](../api/test-helpers)
 for a more comprehensive reference.
 
 
@@ -143,4 +143,4 @@ for a response before continuing:
 
 #### Reference
 
-* [Helpers API](../api/helpers)
+* [Test Helpers API](../api/test-helpers)

--- a/docs/guides/writing-spec-helpers.md
+++ b/docs/guides/writing-spec-helpers.md
@@ -4,7 +4,7 @@ title: Writing your own spec helpers
 sidebar_label: Writing your own spec helpers
 ---
 
-If you'd like to test something that's not included in the [Cavy helpers](../api/helpers),
+If you'd like to test something that's not included in the [Cavy helpers](../api/test-helpers),
 you can write your own spec helper function.
 
 Your function will need to be **asynchronous** and should **throw an error** in

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -11,7 +11,8 @@
           "getting-started/writing-tests"
         ]
       },
-      "getting-started/running-tests"
+      "getting-started/running-tests",
+      "getting-started/sample-app"
     ],
     "API reference": [
       "api/tester",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -13,6 +13,13 @@
       },
       "getting-started/running-tests"
     ],
+    "API reference": [
+      "api/tester",
+      "api/test-hooks",
+      "api/test-helpers",
+      "api/commands",
+      "api/cavy-native-reporter"
+    ],
     "Guides": [
       "guides/specifing-a-custom-app-entry-point",
       "guides/writing-spec-helpers",
@@ -27,13 +34,6 @@
           "guides/cavy-native-reporter/reporting-to-android"
         ]
       }
-    ],
-    "API reference": [
-      "api/commands",
-      "api/helpers",
-      "api/tester",
-      "api/test-hooks",
-      "api/cavy-native-reporter"
     ]
   }
 }

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -24,7 +24,7 @@ const siteConfig = {
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
     { doc: "getting-started/installing", label: "Documentation" },
-    { doc: "api/helpers", label: "API" },
+    { doc: "api/test-helpers", label: "API" },
     { href: "https://github.com/pixielabs/cavy", label: "GitHub" },
     { href: "https://www.pivotaltracker.com/n/projects/2447582", label: "Roadmap" },
     { doc: "faq", label: "FAQ" }


### PR DESCRIPTION
Before adding documentation for the new features we're introducing, I wanted to tidy up the existing docs - they'd started getting a little disjointed through repeated additions and also, we were still telling people they couldn't use Expo full stop.

The main changes, other than smartening up some wording are:

- Additional advice on how to use Expo and cavy-cli where appropriate.
- Removing the reference to all the test helpers in the Getting Started with writing tests section. This was just a worse version of what we have in the API reference section! I've pointed people there instead.
- Renamed 'Helpers' page to 'Test helpers' to keep language more consistent, also helpers for what?
- Moved the link to the sample app to a separate page - it was tucked at the end of the cavy-cli commands page. As a dev, I always love seeing example repos and this was hard to find.
- Re-ordered the API sidebar menu so that it follows the flow of the Getting started instructions.